### PR TITLE
[refactor] ホームビューとメインCSSのスタイル調整

### DIFF
--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -3,7 +3,6 @@
 #app {
   max-width: 1280px;
   margin: 0 auto;
-  padding: 2rem;
   font-weight: normal;
 }
 
@@ -12,7 +11,6 @@ a,
   text-decoration: none;
   color: hsla(160, 100%, 37%, 1);
   transition: 0.4s;
-  padding: 3px;
 }
 
 @media (hover: hover) {
@@ -30,6 +28,5 @@ a,
   #app {
     display: grid;
     grid-template-columns: 1fr 1fr;
-    padding: 0 2rem;
   }
 }

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -99,19 +99,19 @@ const handleLogout = async () => {
 main {
   flex: 1;
   width: 100%;
-  max-width: 1200px;
-  margin: 0 auto;
-  padding: 2rem 1rem;
+  max-width: 100%;
+  margin: 0;
 }
 
 .training-tabs {
   display: flex;
   flex-direction: column;
   width: 100%;
+  height: 100%;
   background-color: white;
   overflow: hidden;
-  border-radius: 8px;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  border-radius: 0;
+  box-shadow: none;
 }
 
 .tabs-header {
@@ -121,7 +121,7 @@ main {
   background-color: var(--primary-color);
   color: white;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-  border-radius: 8px 8px 0 0;
+  border-radius: 0;
 }
 
 .header-content {
@@ -256,7 +256,7 @@ main {
 
 @media (max-width: 375px) {
   main {
-    padding: 1rem 0.5rem;
+    padding: 0;
   }
 
   .header-content {


### PR DESCRIPTION
- メインビューのレイアウトを全幅に変更
- パディングとマージンを削除
- トレーニングタブのスタイルを簡素化
- モバイルビューでのレイアウト微調整